### PR TITLE
feat: Implement waypoint deletion and data clearing

### DIFF
--- a/app/services/db.ts
+++ b/app/services/db.ts
@@ -103,6 +103,16 @@ export async function getWaypointById(
   return db.get(STORE_NAME, id);
 }
 
+export async function deleteWaypoint(id: number): Promise<void> {
+  const db = await openWaypointsDB();
+  await db.delete(STORE_NAME, id);
+}
+
+export async function clearAllWaypoints(): Promise<void> {
+  const db = await openWaypointsDB();
+  await db.clear(STORE_NAME);
+}
+
 export function waypointsToGeoJSON(
   waypoints: Waypoint[]
 ): GeoJSON.FeatureCollection<GeoJSON.Point> {


### PR DESCRIPTION
This commit introduces two new features to enhance waypoint management:

1.  **Delete Specific Waypoint**:
    *   Adds a `deleteWaypoint` function to the `db.ts` service to remove a waypoint by its ID from IndexedDB.
    *   Integrates a "Delete" button for each waypoint in the `SavedWaypoints` list.
    *   You will be prompted for confirmation before deletion.

2.  **Delete All Waypoint Data**:
    *   Adds a `clearAllWaypoints` function to the `db.ts` service to remove all waypoints from IndexedDB.
    *   Integrates a "Delete All Data" button in the `SavedWaypoints` view.
    *   You will be prompted for confirmation before clearing all data.

Unit tests have been added for the new `deleteWaypoint` and `clearAllWaypoints` functions in `db.test.ts` to ensure their reliability. UI tests for the `SavedWaypoints` component changes were considered but deferred due to the existing global mocking strategy for the database service.