### PR TITLE
feat: Allow creating routes from saved waypoints

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -14,6 +14,7 @@ export default [
         index("routes/saved_waypoints.tsx"),
         route("/add", "routes/add_waypoint.tsx"),
         route("/edit/:wpId", "routes/edit_waypoint.tsx"),
+        route("/create_route", "routes/create_route.tsx"),
     ]),
     route("/settings", "routes/settings.tsx"),
 ] satisfies RouteConfig;

--- a/app/routes/create_route.test.tsx
+++ b/app/routes/create_route.test.tsx
@@ -1,0 +1,232 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import CreateRoute from "./create_route"; // Adjust path as necessary
+import * as db from "../services/db"; // To mock getSavedWaypoints
+import { Waypoint } from "../services/db"; // Import Waypoint type
+
+// Mock react-router useNavigate
+const mockNavigate = vi.fn();
+vi.mock("react-router", () => ({
+  ...vi.importActual("react-router"),
+  useNavigate: () => mockNavigate,
+}));
+
+// Mock data
+const mockWaypoints: Waypoint[] = [
+  {
+    id: 1,
+    name: "Waypoint 1",
+    latitude: 10,
+    longitude: 20,
+    createdAt: new Date().toISOString(),
+    altitude: 100,
+    imageDataUrl: null,
+  },
+  {
+    id: 2,
+    name: "Waypoint 2",
+    latitude: 11,
+    longitude: 21,
+    createdAt: new Date().toISOString(),
+    altitude: 101,
+    imageDataUrl: "data:image/png;base64,test",
+  },
+  {
+    id: 3,
+    name: "Waypoint 3",
+    latitude: 12,
+    longitude: 22,
+    createdAt: new Date().toISOString(),
+    altitude: null,
+    imageDataUrl: null,
+  },
+];
+
+describe("CreateRoute Component", () => {
+  let mockGetSavedWaypoints: any;
+  let mockCreateObjectURL: any;
+  let mockRevokeObjectURL: any;
+  let mockAlert: any;
+
+  beforeEach(() => {
+    mockGetSavedWaypoints = vi
+      .spyOn(db, "getSavedWaypoints")
+      .mockResolvedValue(mockWaypoints);
+
+    // Mock URL.createObjectURL and URL.revokeObjectURL
+    mockCreateObjectURL = vi.fn((blob) => `blob:${blob.size}#mockURL`);
+    mockRevokeObjectURL = vi.fn();
+    global.URL.createObjectURL = mockCreateObjectURL;
+    global.URL.revokeObjectURL = mockRevokeObjectURL;
+
+    // Mock window.alert
+    mockAlert = vi.spyOn(window, "alert").mockImplementation(() => {});
+
+    // Mock document.createElement to track the download link
+    // Store the mocked click function to check if it was called
+    const mockAnchorClick = vi.fn();
+    const originalCreateElement = document.createElement; // Save original
+    vi.spyOn(document, "createElement").mockImplementation((tagName: string) => {
+      // Use the saved original function for creating the element
+      const elem = originalCreateElement.call(document, tagName);
+      if (tagName.toLowerCase() === 'a') {
+        // @ts-ignore
+        elem.click = mockAnchorClick;
+      }
+      return elem;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders loading state initially", () => {
+    render(<CreateRoute />);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("fetches and displays waypoints", async () => {
+    render(<CreateRoute />);
+    await waitFor(() => {
+      expect(screen.getByText("Waypoint 1")).toBeInTheDocument();
+      expect(screen.getByText("Waypoint 2")).toBeInTheDocument();
+      expect(screen.getByText("Waypoint 3")).toBeInTheDocument();
+    });
+    expect(mockGetSavedWaypoints).toHaveBeenCalledTimes(1);
+  });
+
+  it("displays an error message if fetching waypoints fails", async () => {
+    mockGetSavedWaypoints.mockRejectedValueOnce(
+      new Error("Failed to fetch")
+    );
+    render(<CreateRoute />);
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to load saved waypoints. Please try again.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("displays message when no waypoints are available", async () => {
+    mockGetSavedWaypoints.mockResolvedValueOnce([]);
+    render(<CreateRoute />);
+    await waitFor(() => {
+      expect(screen.getByText("No waypoints available to create a route. Add some waypoints first.")).toBeInTheDocument();
+    });
+  });
+
+  it("allows selecting and deselecting waypoints and shows/hides create button", async () => {
+    render(<CreateRoute />);
+    await waitFor(() => screen.getByText("Waypoint 1"));
+
+    const checkbox1 = screen.getByLabelText("Select waypoint Waypoint 1");
+    const checkbox2 = screen.getByLabelText("Select waypoint Waypoint 2");
+
+    fireEvent.click(checkbox1);
+    expect(checkbox1).toBeChecked();
+    expect(checkbox2).not.toBeChecked();
+    // Create and Download button should not be visible with only 1 waypoint selected
+    expect(screen.queryByText(/Create and Download Route/)).not.toBeInTheDocument();
+
+    fireEvent.click(checkbox2);
+    expect(checkbox1).toBeChecked();
+    expect(checkbox2).toBeChecked();
+    // Button should be visible with 2 waypoints selected
+    expect(screen.getByText("Create and Download Route (2 waypoints)")).toBeInTheDocument();
+
+    fireEvent.click(checkbox1); // Deselect waypoint 1
+    expect(checkbox1).not.toBeChecked();
+    expect(checkbox2).toBeChecked();
+    // Button should hide again with only 1 waypoint selected
+    expect(screen.queryByText(/Create and Download Route/)).not.toBeInTheDocument();
+  });
+
+  it("navigates back when back button is clicked", async () => {
+    render(<CreateRoute />);
+    await waitFor(() => screen.getByText("Waypoint 1"));
+
+    // The back button is the first button in the header
+    const header = screen.getByRole('banner');
+    const backButton = header.querySelector('button');
+    expect(backButton).toBeInTheDocument();
+    if (backButton) {
+      fireEvent.click(backButton);
+    }
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
+  });
+
+  it("does not show create route button if less than 2 waypoints are selected", async () => {
+    render(<CreateRoute />);
+    await waitFor(() => screen.getByText("Waypoint 1"));
+
+    // No waypoints selected initially
+    expect(screen.queryByText(/Create and Download Route/)).not.toBeInTheDocument();
+
+    const checkbox1 = screen.getByLabelText("Select waypoint Waypoint 1");
+    fireEvent.click(checkbox1); // Select 1 waypoint
+
+    expect(screen.queryByText(/Create and Download Route/)).not.toBeInTheDocument();
+    expect(mockAlert).not.toHaveBeenCalled(); // Alert should not be called as button isn't clicked
+  });
+
+
+  it("creates and downloads a GeoJSON file for a valid route", async () => {
+    render(<CreateRoute />);
+    await waitFor(() => screen.getByText("Waypoint 1"));
+
+    const checkbox1 = screen.getByLabelText("Select waypoint Waypoint 1");
+    const checkbox2 = screen.getByLabelText("Select waypoint Waypoint 2");
+    fireEvent.click(checkbox1);
+    fireEvent.click(checkbox2);
+
+    const createButton = screen.getByText("Create and Download Route (2 waypoints)");
+    fireEvent.click(createButton);
+
+    expect(mockCreateObjectURL).toHaveBeenCalled();
+    // @ts-ignore - check that the mocked anchor click was called
+    expect(vi.mocked(document.createElement('a').click)).toHaveBeenCalled();
+
+
+    // Verify GeoJSON structure from the blob passed to createObjectURL
+    const blobArg = mockCreateObjectURL.mock.calls[0][0] as Blob;
+    expect(blobArg.type).toBe("application/json");
+
+    const reader = new FileReader();
+    await new Promise<void>((resolve, reject) => { // Ensure void promise for async/await
+      reader.onload = () => {
+        const geojsonData = JSON.parse(reader.result as string);
+        expect(geojsonData.type).toBe("FeatureCollection");
+        expect(geojsonData.features.length).toBe(1);
+        expect(geojsonData.features[0].type).toBe("Feature");
+        expect(geojsonData.features[0].properties.name).toBe("New Route");
+        expect(geojsonData.features[0].geometry.type).toBe("LineString");
+        expect(geojsonData.features[0].geometry.coordinates).toEqual([
+          [mockWaypoints[0].longitude, mockWaypoints[0].latitude],
+          [mockWaypoints[1].longitude, mockWaypoints[1].latitude],
+        ]);
+        resolve();
+      };
+      reader.onerror = reject;
+      reader.readAsText(blobArg);
+    });
+
+    expect(mockRevokeObjectURL).toHaveBeenCalled();
+  });
+
+   it("uses waypoint image if available, otherwise placeholder", async () => {
+    render(<CreateRoute />);
+    await waitFor(() => screen.getByText("Waypoint 1"));
+
+    const waypoint1Item = screen.getByText("Waypoint 1").closest('li');
+    expect(waypoint1Item?.querySelector('img')).toBeNull();
+    expect(waypoint1Item?.querySelector('svg')).toBeInTheDocument();
+
+    const waypoint2Item = screen.getByText("Waypoint 2").closest('li');
+    const imgElement = waypoint2Item?.querySelector('img');
+    expect(imgElement).toBeInTheDocument();
+    expect(imgElement).toHaveAttribute('src', mockWaypoints[1].imageDataUrl);
+    expect(imgElement).toHaveAttribute('alt', mockWaypoints[1].name);
+  });
+
+});

--- a/app/routes/create_route.tsx
+++ b/app/routes/create_route.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import {
+  getSavedWaypoints,
+  type Waypoint,
+  waypointsToGeoJSON,
+} from "../services/db";
+import { Button } from "~/components/button";
+import { Checkbox } from "~/components/checkbox";
+import { ArrowLeftIcon, ArrowDownOnSquareIcon, MapPinIcon } from "@heroicons/react/24/outline";
+
+export default function CreateRoute() {
+  const [waypoints, setWaypoints] = useState<Waypoint[]>([]);
+  const [selectedWaypoints, setSelectedWaypoints] = useState<Waypoint[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    async function fetchWaypoints() {
+      try {
+        setIsLoading(true);
+        const savedWaypoints = await getSavedWaypoints();
+        setWaypoints(savedWaypoints);
+        setError(null);
+      } catch (err) {
+        console.error("Error fetching saved waypoints:", err);
+        setError("Failed to load saved waypoints. Please try again.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    fetchWaypoints();
+  }, []);
+
+  const handleNavigateBack = () => {
+    navigate(-1);
+  };
+
+  const handleWaypointToggle = (waypoint: Waypoint) => {
+    setSelectedWaypoints((prevSelected) =>
+      prevSelected.find((wp) => wp.id === waypoint.id)
+        ? prevSelected.filter((wp) => wp.id !== waypoint.id)
+        : [...prevSelected, waypoint]
+    );
+  };
+
+  const handleCreateRoute = () => {
+    if (selectedWaypoints.length < 2) {
+      alert("Please select at least two waypoints to create a route.");
+      return;
+    }
+
+    const routeGeoJSON = {
+      type: "FeatureCollection",
+      features: [
+        {
+          type: "Feature",
+          properties: {
+            name: "New Route", // Or generate a name based on selected waypoints
+          },
+          geometry: {
+            type: "LineString",
+            coordinates: selectedWaypoints.map((wp) => [
+              wp.longitude,
+              wp.latitude,
+            ]),
+          },
+        },
+      ],
+    };
+
+    const jsonString = JSON.stringify(routeGeoJSON, null, 2);
+    const blob = new Blob([jsonString], { type: "application/json" });
+    const href = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = href;
+    link.download = "route.geojson";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(href);
+  };
+
+  return (
+    <div className="flex flex-col h-screen">
+      <header className="flex items-center justify-between p-4 border-b border-slate-200">
+        <Button onClick={handleNavigateBack} className="p-2">
+          <ArrowLeftIcon className="h-6 w-6" />
+        </Button>
+        <h1 className="text-lg font-bold">Create Route</h1>
+        <div className="w-10"></div> {/* Placeholder for right side icon if needed */}
+      </header>
+
+      <main className="flex-grow overflow-y-auto">
+        {isLoading && <p className="p-4 text-center">Loading...</p>}
+        {error && <p className="p-4 text-center text-red-500">{error}</p>}
+        {!isLoading && !error && waypoints.length === 0 && (
+          <p className="p-4 text-center text-slate-500">
+            No waypoints available to create a route. Add some waypoints first.
+          </p>
+        )}
+        {!isLoading && !error && waypoints.length > 0 && (
+          <ul className="divide-y divide-slate-200">
+            {waypoints.map((waypoint) => (
+              <li key={waypoint.id} className="p-4 flex items-center gap-4">
+                <Checkbox
+                  checked={selectedWaypoints.some((wp) => wp.id === waypoint.id)}
+                  onChange={() => handleWaypointToggle(waypoint)}
+                  aria-label={`Select waypoint ${waypoint.name}`}
+                />
+                {waypoint.imageDataUrl ? (
+                  <img
+                    src={waypoint.imageDataUrl}
+                    alt={waypoint.name}
+                    className="h-12 w-12 rounded-lg object-cover"
+                  />
+                ) : (
+                  <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-slate-200">
+                    <MapPinIcon className="h-6 w-6 text-slate-500" />
+                  </div>
+                )}
+                <div className="flex-grow">
+                  <h2 className="font-bold text-green-700">
+                    {waypoint.name}
+                  </h2>
+                  <p className="text-sm text-slate-500">
+                    Lat: {waypoint.latitude.toFixed(4)}, Lon:{" "}
+                    {waypoint.longitude.toFixed(4)}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+
+      {selectedWaypoints.length > 1 && (
+        <footer className="p-4 border-t border-slate-200">
+          <Button
+            onClick={handleCreateRoute}
+            className="w-full flex items-center justify-center gap-2"
+          >
+            <ArrowDownOnSquareIcon className="h-5 w-5" />
+            Create and Download Route ({selectedWaypoints.length} waypoints)
+          </Button>
+        </footer>
+      )}
+    </div>
+  );
+}

--- a/app/routes/saved_waypoints.tsx
+++ b/app/routes/saved_waypoints.tsx
@@ -15,6 +15,7 @@ import {
   TrashIcon,
   ShareIcon,
   MapPinIcon,
+  MapIcon, // Added MapIcon for the new button
 } from "@heroicons/react/24/outline";
 
 export default function SavedWaypoints() {
@@ -203,7 +204,15 @@ export default function SavedWaypoints() {
         )}
       </main>
 
-      <footer className="p-4 border-t border-slate-200">
+      <footer className="p-4 border-t border-slate-200 space-y-2">
+        <Button
+          onClick={() => navigate("/waypoints/create_route")}
+          className="w-full flex items-center justify-center gap-2"
+          color="green"
+        >
+          <MapIcon className="h-5 w-5" />
+          Create Route from Waypoints
+        </Button>
         <Button
           onClick={handleExportToGeoJSON}
           className="w-full flex items-center justify-center gap-2"


### PR DESCRIPTION
This commit introduces the functionality to create and download routes as GeoJSON files by selecting from a list of saved waypoints.

- Adds a new route `/waypoints/create_route` for this feature.
- The `CreateRoute` component fetches saved waypoints, allows users to select multiple waypoints, and generates a GeoJSON LineString feature.
- Users can download the generated route.
- Adds a button on the 'Saved Waypoints' page to navigate to the new route creation page.
- Includes comprehensive tests for the new component, covering data fetching, waypoint selection, route generation, and file download.