### PR TITLE
Add import/export functionality for waypoints and routes

### DIFF
--- a/app/routes/settings.test.tsx
+++ b/app/routes/settings.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import Settings from "./settings";
+import * as db from "~/services/db";
+import { vi } from "vitest";
+import "@testing-library/jest-dom";
+
+// Mock the db module
+vi.mock("~/services/db", async () => {
+  const actual = await vi.importActual("~/services/db");
+  return {
+    ...actual,
+    exportWaypoints: vi.fn(),
+    importWaypoints: vi.fn(),
+    exportRoutes: vi.fn(),
+    importRoutes: vi.fn(),
+    clearAllWaypoints: vi.fn(),
+  };
+});
+
+// Mock file-saver or URL.createObjectURL if used directly for downloads
+global.URL.createObjectURL = vi.fn(() => "mock-url");
+global.URL.revokeObjectURL = vi.fn(); // Mock revokeObjectURL
+const mockAnchorClick = vi.fn();
+const mockAnchorRemove = vi.fn();
+
+// Store original properties
+const originalAnchorClick = Object.getOwnPropertyDescriptor(HTMLAnchorElement.prototype, 'click');
+const originalAnchorRemove = Object.getOwnPropertyDescriptor(HTMLAnchorElement.prototype, 'remove');
+
+Object.defineProperty(HTMLAnchorElement.prototype, 'click', {
+  value: mockAnchorClick,
+  writable: true,
+  configurable: true,
+});
+Object.defineProperty(HTMLAnchorElement.prototype, 'remove', {
+ value: mockAnchorRemove,
+ writable: true,
+ configurable: true,
+});
+
+
+describe("Settings Page", () => {
+  beforeEach(() => {
+    vi.resetAllMocks(); // Reset mocks before each test
+  });
+
+  it("renders settings heading", () => {
+    render(<Settings />);
+    expect(screen.getByRole("heading", { name: /settings/i })).toBeInTheDocument();
+  });
+
+  describe("Waypoints Import/Export", () => {
+    it("calls exportWaypoints and triggers download on export click", async () => {
+      (db.exportWaypoints as vi.Mock).mockResolvedValue('{"type":"FeatureCollection","features":[]}');
+      render(<Settings />);
+      fireEvent.click(screen.getByRole("button", { name: /export waypoints/i }));
+
+      await waitFor(() => expect(db.exportWaypoints).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(mockAnchorClick).toHaveBeenCalledTimes(1));
+      // Check if success message appears (optional, based on implementation)
+      // await waitFor(() => expect(screen.getByText(/operation successful/i)).toBeInTheDocument());
+    });
+
+    it("calls importWaypoints on file input change", async () => {
+      render(<Settings />);
+      const file = new File(['{"type":"FeatureCollection","features":[]}'], "waypoints.geojson", { type: "application/json" });
+      const fileInput = screen.getByTestId("import-waypoints-input");
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => expect(db.importWaypoints).toHaveBeenCalledTimes(1));
+      expect(db.importWaypoints).toHaveBeenCalledWith('{"type":"FeatureCollection","features":[]}');
+      await waitFor(() => expect(screen.getByText(/operation successful/i)).toBeInTheDocument());
+    });
+
+     it("shows error message on exportWaypoints failure", async () => {
+      (db.exportWaypoints as vi.Mock).mockRejectedValue(new Error("Export failed"));
+      render(<Settings />);
+      fireEvent.click(screen.getByRole("button", { name: /export waypoints/i }));
+
+      await waitFor(() => expect(db.exportWaypoints).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(screen.getByText(/an error occurred/i)).toBeInTheDocument());
+    });
+
+    it("shows error message on importWaypoints failure", async () => {
+      (db.importWaypoints as vi.Mock).mockRejectedValue(new Error("Import failed"));
+      render(<Settings />);
+      const file = new File(["invalid json"], "waypoints.geojson", { type: "application/json" });
+      const fileInput = screen.getByTestId("import-waypoints-input");
+
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => expect(db.importWaypoints).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(screen.getByText(/an error occurred/i)).toBeInTheDocument());
+    });
+  });
+
+  describe("Routes Import/Export", () => {
+    it("calls exportRoutes and triggers download on export click", async () => {
+      (db.exportRoutes as vi.Mock).mockResolvedValue('[]');
+      render(<Settings />);
+      fireEvent.click(screen.getByRole("button", { name: /export routes/i }));
+
+      await waitFor(() => expect(db.exportRoutes).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(mockAnchorClick).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(screen.getByText(/operation successful/i)).toBeInTheDocument());
+    });
+
+    it("calls importRoutes on file input change", async () => {
+      render(<Settings />);
+      const file = new File(['[]'], "routes.json", { type: "application/json" });
+      const fileInput = screen.getByTestId("import-routes-input");
+
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => expect(db.importRoutes).toHaveBeenCalledTimes(1));
+      expect(db.importRoutes).toHaveBeenCalledWith('[]');
+      await waitFor(() => expect(screen.getByText(/operation successful/i)).toBeInTheDocument());
+    });
+
+    it("shows error message on exportRoutes failure", async () => {
+      (db.exportRoutes as vi.Mock).mockRejectedValue(new Error("Export failed"));
+      render(<Settings />);
+      fireEvent.click(screen.getByRole("button", { name: /export routes/i }));
+
+      await waitFor(() => expect(db.exportRoutes).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(screen.getByText(/an error occurred/i)).toBeInTheDocument());
+    });
+
+    it("shows error message on importRoutes failure", async () => {
+        (db.importRoutes as vi.Mock).mockRejectedValue(new Error("Import failed"));
+        render(<Settings />);
+        const file = new File(["invalid json"], "routes.json", { type: "application/json" });
+        const fileInput = screen.getByTestId("import-routes-input");
+
+        fireEvent.change(fileInput, { target: { files: [file] } });
+
+        await waitFor(() => expect(db.importRoutes).toHaveBeenCalledTimes(1));
+        await waitFor(() => expect(screen.getByText(/an error occurred/i)).toBeInTheDocument());
+    });
+  });
+
+  describe("Danger Zone", () => {
+    it("opens delete confirmation dialog on 'Delete all waypoints' click", () => {
+      render(<Settings />);
+      fireEvent.click(screen.getByRole("button", { name: /delete all waypoints/i }));
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByText(/are you sure you want to delete all waypoint data/i)).toBeInTheDocument();
+    });
+
+    it("calls clearAllWaypoints and closes dialog on confirm delete", async () => {
+      render(<Settings />);
+      fireEvent.click(screen.getByRole("button", { name: /delete all waypoints/i }));
+      await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+      fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+      await waitFor(() => expect(db.clearAllWaypoints).toHaveBeenCalledTimes(1));
+      await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText(/operation successful/i)).toBeInTheDocument());
+    });
+
+    it("closes dialog on cancel delete", async () => {
+      render(<Settings />);
+      fireEvent.click(screen.getByRole("button", { name: /delete all waypoints/i }));
+      await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+      await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    });
+  });
+});

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -1,24 +1,157 @@
-import {useState} from 'react';
+import {useState, useRef} from 'react';
 import {Button} from '~/components/button'
 import {Dialog, DialogActions, DialogBody, DialogTitle} from '~/components/dialog'
 import {Heading} from '~/components/heading'
-import {clearAllWaypoints} from "~/services/db";
+import {clearAllWaypoints, exportWaypoints, importWaypoints, exportRoutes, importRoutes} from "~/services/db";
+import {Text} from "~/components/text";
 
 
 export default function Settings() {
     const [deleteAllDialog, setDeleteAllDialog] = useState(false);
+    const [showSuccessMessage, setShowSuccessMessage] = useState(false);
+    const [showErrorMessage, setShowErrorMessage] = useState(false);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const routeFileInputRef = useRef<HTMLInputElement>(null);
 
     const handleDeleteAllData = async () => {
-        await clearAllWaypoints()
+        await clearAllWaypoints();
+        setDeleteAllDialog(false);
+        setShowSuccessMessage(true);
+        setTimeout(() => setShowSuccessMessage(false), 3000);
+    };
+
+    const handleExportWaypoints = async () => {
+        try {
+            const geoJsonString = await exportWaypoints();
+            const blob = new Blob([geoJsonString], {type: "application/json"});
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = "waypoints.geojson";
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            setShowSuccessMessage(true);
+            setTimeout(() => setShowSuccessMessage(false), 3000);
+        } catch (error) {
+            setShowErrorMessage(true);
+            setTimeout(() => setShowErrorMessage(false), 3000);
+            console.error("Error exporting waypoints:", error);
+        }
+    };
+
+    const handleImportWaypoints = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = async (e) => {
+                try {
+                    const geoJsonString = e.target?.result as string;
+                    await importWaypoints(geoJsonString);
+                    setShowSuccessMessage(true);
+                    setTimeout(() => setShowSuccessMessage(false), 3000);
+                } catch (error) {
+                    setShowErrorMessage(true);
+                    setTimeout(() => setShowErrorMessage(false), 3000);
+                    console.error("Error importing waypoints:", error);
+                }
+            };
+            reader.readAsText(file);
+        }
+    };
+
+    const handleExportRoutes = async () => {
+        try {
+            const jsonString = await exportRoutes();
+            const blob = new Blob([jsonString], {type: "application/json"});
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = "routes.json";
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            setShowSuccessMessage(true);
+            setTimeout(() => setShowSuccessMessage(false), 3000);
+        } catch (error) {
+            setShowErrorMessage(true);
+            setTimeout(() => setShowErrorMessage(false), 3000);
+            console.error("Error exporting routes:", error);
+        }
+    };
+
+    const handleImportRoutes = async (event: React.ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        if (file) {
+            const reader = new FileReader();
+            reader.onload = async (e) => {
+                try {
+                    const jsonString = e.target?.result as string;
+                    await importRoutes(jsonString);
+                    setShowSuccessMessage(true);
+                    setTimeout(() => setShowSuccessMessage(false), 3000);
+                } catch (error) {
+                    setShowErrorMessage(true);
+                    setTimeout(() => setShowErrorMessage(false), 3000);
+                    console.error("Error importing routes:", error);
+                }
+            };
+            reader.readAsText(file);
+        }
     };
 
     return (
         <div>
             <Heading>Settings</Heading>
             <p>Manage your application settings here.</p>
-            <Button color="red" onClick={() => setDeleteAllDialog(true)}>
-                Delete all waypoints
-            </Button>
+
+            {showSuccessMessage && <Text color="green">Operation successful!</Text>}
+            {showErrorMessage && <Text color="red">An error occurred.</Text>}
+
+            <div className="mt-4 space-y-4">
+                <div>
+                    <Heading level={2}>Waypoints</Heading>
+                    <div className="flex space-x-2 mt-2">
+                        <Button onClick={() => fileInputRef.current?.click()}>Import Waypoints</Button>
+                        <input
+                            type="file"
+                            ref={fileInputRef}
+                            style={{display: "none"}}
+                            accept=".geojson"
+                            onChange={handleImportWaypoints}
+                            data-testid="import-waypoints-input"
+                        />
+                        <Button onClick={handleExportWaypoints}>Export Waypoints</Button>
+                    </div>
+                </div>
+
+                <div>
+                    <Heading level={2}>Routes</Heading>
+                     <div className="flex space-x-2 mt-2">
+                        <Button onClick={() => routeFileInputRef.current?.click()}>Import Routes</Button>
+                        <input
+                            type="file"
+                            ref={routeFileInputRef}
+                            style={{display: "none"}}
+                            accept=".json"
+                            onChange={handleImportRoutes}
+                            data-testid="import-routes-input"
+                        />
+                        <Button onClick={handleExportRoutes}>Export Routes</Button>
+                    </div>
+                </div>
+
+                <div>
+                    <Heading level={2}>Danger Zone</Heading>
+                    <Button color="red" onClick={() => setDeleteAllDialog(true)} className="mt-2">
+                        Delete all waypoints
+                    </Button>
+                </div>
+            </div>
+
+
             <Dialog
                 open={deleteAllDialog}
                 onClose={() => setDeleteAllDialog(false)}


### PR DESCRIPTION
This change introduces the ability to import and export waypoints (as GeoJSON) and routes (as JSON) from the settings page.

Key changes:
- Added `exportWaypoints`, `importWaypoints`, `exportRoutes`, and `importRoutes` functions to `app/services/db.ts`.
- Updated `app/routes/settings.tsx` to include UI elements (buttons and file inputs) for these actions.
- Added corresponding unit tests for the database functions and integration tests for the settings page UI.