### PR TITLE
feat: Add GeoJSON Polygon support for routes

### DIFF
--- a/app/routes/map.tsx
+++ b/app/routes/map.tsx
@@ -43,7 +43,7 @@ type UserPosition = {
 function MapController({
                            routeGeoJSON,
                        }: {
-    routeGeoJSON: GeoJSON.Feature<GeoJSON.LineString> | null;
+    routeGeoJSON: GeoJSON.Feature<GeoJSON.LineString | GeoJSON.Polygon> | null;
 }) {
     const map = useMap();
 
@@ -68,7 +68,7 @@ function ActualMap({userPosition}: { userPosition: UserPosition }) {
     const [waypointsGeoJSON, setWaypointsGeoJSON] =
         useState<GeoJSON.FeatureCollection<GeoJSON.Point, Waypoint> | null>(null);
     const [routeToDisplayGeoJSON, setRouteToDisplayGeoJSON] =
-        useState<GeoJSON.Feature<GeoJSON.LineString> | null>(null);
+        useState<GeoJSON.Feature<GeoJSON.LineString | GeoJSON.Polygon> | null>(null);
     const [routeName, setRouteName] = useState<string | null>(null);
 
     useEffect(() => {
@@ -189,9 +189,14 @@ function ActualMap({userPosition}: { userPosition: UserPosition }) {
 
                 {routeToDisplayGeoJSON && (
                     <GeoJSON
-                        key={JSON.stringify(routeToDisplayGeoJSON.geometry.coordinates)}
+                        key={JSON.stringify(routeToDisplayGeoJSON.geometry)} // Use entire geometry for key
                         data={routeToDisplayGeoJSON}
-                        style={() => ({color: "red", weight: 4, opacity: 0.8})}
+                        style={(feature) => {
+                            if (feature?.geometry.type === "Polygon") {
+                                return { color: "blue", weight: 2, opacity: 0.5, fillColor: "lightblue", fillOpacity: 0.3 };
+                            }
+                            return { color: "red", weight: 4, opacity: 0.8 }; // Default for LineString
+                        }}
                     >
                         {routeName && <Popup>{routeName}</Popup>}
                     </GeoJSON>


### PR DESCRIPTION
This commit enhances the application's routing capabilities to include support for GeoJSON Polygon shapes, in addition to the existing LineString support.

Key changes:

- Updated the `Route` interface in `app/services/db.ts` to allow `geometry` to be `GeoJSON.LineString | GeoJSON.Polygon`.
- Modified `addRoute`, `exportRoutes`, and `importRoutes` in `app/services/db.ts` to correctly process and store these generalized route geometries.
- Updated type definitions in `app/routes/map.tsx` for `MapController` and `ActualMap` components to handle features with either LineString or Polygon geometries.
- Implemented conditional styling in `app/routes/map.tsx` to render Polygons with a blue outline and light blue fill, distinguishing them from LineStrings which remain red.
- Adjusted the `key` prop for the route GeoJSON layer to use the entire geometry object, ensuring proper re-renders when geometry types or structures change.

These changes allow users to import, view, and export routes that include polygonal areas, providing more versatile mapping options.