### PR TITLE
Fix: Add BASE_URL to waypoint edit link

### DIFF
--- a/app/routes/map.tsx
+++ b/app/routes/map.tsx
@@ -139,7 +139,7 @@ function ActualMap({userPosition}: { userPosition: UserPosition }) {
                     feature.properties.name || "Waypoint"
                 } image" style="max-width: 150px; max-height: 100px; object-fit: cover; margin-top: 5px; border-radius: 4px;" />`;
             }
-            popupContent += `<br /><a href="/waypoints/edit/${feature.properties.id}" style="margin-top: 5px; display: inline-block;">Edit Waypoint</a>`;
+            popupContent += `<br /><a href="${import.meta.env.BASE_URL}waypoints/edit/${feature.properties.id}" style="margin-top: 5px; display: inline-block;">Edit Waypoint</a>`;
             layer.bindPopup(popupContent);
         }
     };


### PR DESCRIPTION
The edit waypoint link on the map page was missing the BASE_URL, causing it to fail when the application is hosted under a subpath.

This commit prepends `import.meta.env.BASE_URL` to the link href in `app/routes/map.tsx` to ensure the link is always correct.