### PR TITLE
fix(create-route): Fix saving new routes

### DIFF
--- a/app/routes/create_route.test.tsx
+++ b/app/routes/create_route.test.tsx
@@ -26,25 +26,25 @@ vi.mock("react-router", async () => {
 
 const mockWaypoints: Waypoint[] = [
   {
-    id: "1",
+    id: 1,
     name: "Waypoint 1",
     latitude: 34.0522,
     longitude: -118.2437,
-    createdAt: new Date().toISOString(),
+    createdAt: Date.now(),
   },
   {
-    id: "2",
+    id: 2,
     name: "Waypoint 2",
     latitude: 36.1699,
     longitude: -115.1398,
-    createdAt: new Date().toISOString(),
+    createdAt: Date.now(),
   },
   {
-    id: "3",
+    id: 3,
     name: "Waypoint 3",
     latitude: 40.7128,
     longitude: -74.006,
-    createdAt: new Date().toISOString(),
+    createdAt: Date.now(),
   },
 ];
 
@@ -255,9 +255,19 @@ describe("CreateRoute", () => {
     });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
+    const expectedLineString: GeoJSON.LineString = {
+      type: "LineString",
+      coordinates: [
+        [mockWaypoints[2].longitude, mockWaypoints[2].latitude],
+        [mockWaypoints[1].longitude, mockWaypoints[1].latitude],
+      ],
+    };
 
     await waitFor(() => {
-      expect(db.addRoute).toHaveBeenCalledWith("My Test Route", ["1", "2"]);
+      expect(db.addRoute).toHaveBeenCalledWith(
+        "My Test Route",
+        expectedLineString
+      );
       expect(screen.getByText("Success!")).toBeInTheDocument();
     });
 

--- a/app/routes/create_route.tsx
+++ b/app/routes/create_route.tsx
@@ -37,6 +37,14 @@ import {
 } from "@heroicons/react/24/outline";
 import { PageLayout } from "~/components/page-layout";
 
+function waypointsToLineString(waypoints: Waypoint[]): GeoJSON.LineString {
+  const coordinates = waypoints.map(wp => [wp.longitude, wp.latitude]);
+  return {
+    type: "LineString",
+    coordinates: coordinates,
+  };
+}
+
 export default function CreateRoute() {
   const [waypoints, setWaypoints] = useState<Waypoint[]>([]);
   const [selectedWaypoints, setSelectedWaypoints] = useState<Waypoint[]>([]);
@@ -154,8 +162,8 @@ export default function CreateRoute() {
 
     setIsSaving(true);
     try {
-      const waypointIds = selectedWaypoints.map((wp) => wp.id);
-      await addRoute(name, waypointIds);
+      const routeGeometry = waypointsToLineString(selectedWaypoints);
+      await addRoute(name, routeGeometry);
       showAlert({
         title: "Success!",
         message: `Route '${name}' saved successfully!`,


### PR DESCRIPTION
The `addRoute` function was being called with an array of waypoint IDs instead of a GeoJSON LineString object. This commit fixes the issue by converting the selected waypoints to a LineString before calling `addRoute`.

I also updated the tests to reflect the new implementation and ensure the fix is working correctly.