### PR TITLE
test: update tests and mock out test noise on feat-update-landing-page

### DIFF
--- a/app/routes/add_waypoint.test.tsx
+++ b/app/routes/add_waypoint.test.tsx
@@ -41,6 +41,7 @@ const mockSuccessPosition = {
 describe("AddWaypoint", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     mockNavigate.mockClear();
     mockUseImageCapture.useImageCapture.mockReturnValue({
       capturedImage: null,

--- a/app/routes/saved_waypoints.test.tsx
+++ b/app/routes/saved_waypoints.test.tsx
@@ -88,6 +88,7 @@ const mockWaypoints: db.Waypoint[] = [
 describe("SavedWaypoints", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     mockNavigate.mockClear();
     window.alert = vi.fn();
     URL.createObjectURL = vi.fn(() => "mock-url");

--- a/app/routes/settings.test.tsx
+++ b/app/routes/settings.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import Settings from "./settings";
 import * as db from "~/services/db";
 import { vi } from "vitest";
@@ -51,11 +51,15 @@ Object.defineProperty(HTMLAnchorElement.prototype, 'click', {
 describe("Settings Page", () => {
   beforeEach(() => {
     vi.resetAllMocks(); // Reset mocks before each test
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
-  it("renders settings heading", () => {
+  it("renders settings heading", async () => {
     render(<Settings />);
-    expect(screen.getByRole("heading", { name: /settings/i })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /settings/i })).toBeInTheDocument();
+    });
   });
 
   describe("Waypoints Import/Export", () => {
@@ -65,7 +69,9 @@ describe("Settings Page", () => {
 
       await waitFor(() => expect(mockPostMessage).toHaveBeenCalledTimes(1));
 
-      onmessageCallback({data: '{"type":"FeatureCollection","features":[]}'});
+      act(() => {
+        onmessageCallback({data: '{"type":"FeatureCollection","features":[]}'});
+      });
 
       await waitFor(() => expect(mockAnchorClick).toHaveBeenCalledTimes(1));
     });
@@ -88,7 +94,9 @@ describe("Settings Page", () => {
 
       await waitFor(() => expect(mockPostMessage).toHaveBeenCalledTimes(1));
 
-      onerrorCallback(new Error("Export failed"));
+      act(() => {
+        onerrorCallback(new Error("Export failed"));
+      });
 
       await waitFor(() => expect(screen.getByText(/an error occurred/i)).toBeInTheDocument());
     });
@@ -101,7 +109,9 @@ describe("Settings Page", () => {
 
         await waitFor(() => expect(mockPostMessage).toHaveBeenCalledTimes(1));
 
-        onmessageCallback({data: '{"type":"FeatureCollection","features":[]}'});
+        act(() => {
+          onmessageCallback({data: '{"type":"FeatureCollection","features":[]}'});
+        });
 
         await waitFor(() => expect(mockAnchorClick).toHaveBeenCalledTimes(1));
     });
@@ -111,7 +121,6 @@ describe("Settings Page", () => {
         render(<Settings />);
         const file = new File(['[]'], "routes.json", { type: "application/json" });
         const fileInput = screen.getByTestId("import-routes-input");
-
 
         fireEvent.change(fileInput, { target: { files: [file] } });
 
@@ -125,15 +134,18 @@ describe("Settings Page", () => {
 
         await waitFor(() => expect(mockPostMessage).toHaveBeenCalledTimes(1));
 
-        onerrorCallback(new Error("Export failed"));
+        act(() => {
+          onerrorCallback(new Error("Export failed"));
+        });
 
         await waitFor(() => expect(screen.getByText(/an error occurred/i)).toBeInTheDocument());
       });
   });
 
   describe("Danger Zone", () => {
-    it("opens delete confirmation dialog on 'Delete all waypoints' click", () => {
+    it("opens delete confirmation dialog on 'Delete all waypoints' click", async () => {
       render(<Settings />);
+      await waitFor(() => expect(screen.getByRole("heading", { name: /settings/i })).toBeInTheDocument());
       fireEvent.click(screen.getByRole("button", { name: /delete all waypoints/i }));
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(screen.getByText(/are you sure you want to delete all waypoint data/i)).toBeInTheDocument();

--- a/app/services/db.test.ts
+++ b/app/services/db.test.ts
@@ -8,6 +8,7 @@ import type { Waypoint } from "./db";
 beforeEach(() => {
   indexedDB = new IDBFactory();
   vi.restoreAllMocks();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
 });
 
 // This constant is based on the implementation detail in db.ts

--- a/app/services/statistics.test.ts
+++ b/app/services/statistics.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as db from "./db";
+import {
+  getWaypointCount,
+  getTotalDistance,
+  getRecentTreks,
+} from "./statistics";
+import type { Route } from "./db";
+
+// Mock the db service functions
+vi.mock("./db", async () => {
+  const actual = await vi.importActual("./db");
+  return {
+    ...actual,
+    getSavedWaypoints: vi.fn(),
+    getSavedRoutes: vi.fn(),
+  };
+});
+
+describe("statistics service", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("getWaypointCount", () => {
+    it("should return the correct number of waypoints", async () => {
+      vi.mocked(db.getSavedWaypoints).mockResolvedValue([
+        { id: 1, name: "A", latitude: 0, longitude: 0, createdAt: Date.now() },
+        { id: 2, name: "B", latitude: 0, longitude: 0, createdAt: Date.now() },
+      ]);
+      const count = await getWaypointCount();
+      expect(count).toBe(2);
+    });
+
+    it("should return 0 when there are no waypoints", async () => {
+      vi.mocked(db.getSavedWaypoints).mockResolvedValue([]);
+      const count = await getWaypointCount();
+      expect(count).toBe(0);
+    });
+  });
+
+  describe("getTotalDistance", () => {
+    it("should calculate correct total distance for LineString routes", async () => {
+      // 0,0 to 0,1 is ~111km
+      const route1: Route = {
+        id: 1,
+        name: "Route 1",
+        createdAt: Date.now(),
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [0, 0],
+            [1, 0], // Longitude 1 degree at Equator is ~111km
+          ],
+        },
+      };
+
+      const route2: Route = {
+        id: 2,
+        name: "Route 2",
+        createdAt: Date.now(),
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [0, 0],
+            [0, 1], // Latitude 1 degree is ~111km
+          ],
+        },
+      };
+
+      vi.mocked(db.getSavedRoutes).mockResolvedValue([route1, route2]);
+      const distance = await getTotalDistance();
+
+      // distance from (0,0) to (1,0) is ~111.19 km
+      // distance from (0,0) to (0,1) is ~111.19 km
+      // sum is ~222.39 km, round to 222
+      expect(distance).toBe(222);
+    });
+
+    it("should calculate correct total distance for Polygon routes", async () => {
+      const route1: Route = {
+        id: 1,
+        name: "Polygon Route",
+        createdAt: Date.now(),
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [
+              [0, 0],
+              [1, 0],
+              [1, 1],
+              [0, 1],
+              [0, 0],
+            ],
+          ],
+        },
+      };
+
+      vi.mocked(db.getSavedRoutes).mockResolvedValue([route1]);
+      const distance = await getTotalDistance();
+
+      // Edges: (0,0)->(1,0) [~111.19], (1,0)->(1,1) [~111.19], (1,1)->(0,1) [~111.18], (0,1)->(0,0) [~111.19]
+      // Sum is ~444.77 km, round to 445
+      expect(distance).toBe(445);
+    });
+
+    it("should return 0 when there are no routes", async () => {
+      vi.mocked(db.getSavedRoutes).mockResolvedValue([]);
+      const distance = await getTotalDistance();
+      expect(distance).toBe(0);
+    });
+  });
+
+  describe("getRecentTreks", () => {
+    it("should return the top 3 recent routes", async () => {
+      const routes: Route[] = [
+        { id: 1, name: "A", createdAt: 100, geometry: { type: "LineString", coordinates: [] } },
+        { id: 2, name: "B", createdAt: 90, geometry: { type: "LineString", coordinates: [] } },
+        { id: 3, name: "C", createdAt: 80, geometry: { type: "LineString", coordinates: [] } },
+        { id: 4, name: "D", createdAt: 70, geometry: { type: "LineString", coordinates: [] } },
+      ];
+
+      // db.getSavedRoutes is assumed to return them ordered descending by createdAt (newest first)
+      vi.mocked(db.getSavedRoutes).mockResolvedValue(routes);
+
+      const recent = await getRecentTreks();
+      expect(recent).toHaveLength(3);
+      expect(recent[0].id).toBe(1);
+      expect(recent[1].id).toBe(2);
+      expect(recent[2].id).toBe(3);
+    });
+
+    it("should return all routes if less than 3 exist", async () => {
+      const routes: Route[] = [
+        { id: 1, name: "A", createdAt: 100, geometry: { type: "LineString", coordinates: [] } },
+      ];
+
+      vi.mocked(db.getSavedRoutes).mockResolvedValue(routes);
+
+      const recent = await getRecentTreks();
+      expect(recent).toHaveLength(1);
+      expect(recent[0].id).toBe(1);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12865,7 +12865,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
This PR updates tests to avoid emitting React `act(...)` warnings on state changes caused by mocked async processes or workers responding in `settings.test.tsx`. We also added coverage to ensure accurate behavior in the newly added Trekking Statistics system via `statistics.test.ts`. Finally we silence some warnings/errors from the console that are logged as expected during error cases in test cases.

---
*PR created automatically by Jules for task [9265061428058937672](https://jules.google.com/task/9265061428058937672) started by @marcusholmgren*