### PR TITLE
Fix base64 image data corruption by using multipart/form-data encoding

### DIFF
--- a/app/routes/add_waypoint.tsx
+++ b/app/routes/add_waypoint.tsx
@@ -103,7 +103,7 @@ export default function AddWaypoint({
   };
 
   return (
-    <Form method="post" className="flex flex-col h-screen">
+    <Form method="post" encType="multipart/form-data" className="flex flex-col h-screen">
       <header className="flex items-center justify-between p-4 border-b border-slate-200">
         <Button onClick={handleCancel} className="p-2">
           <ArrowLeftIcon className="h-6 w-6" />

--- a/app/routes/edit_waypoint.tsx
+++ b/app/routes/edit_waypoint.tsx
@@ -136,7 +136,7 @@ export default function EditWaypoint({
   }
 
   return (
-    <Form method="post" className="flex flex-col h-screen">
+    <Form method="post" encType="multipart/form-data" className="flex flex-col h-screen">
       <header className="flex items-center justify-between p-4 border-b border-slate-200">
         <Button onClick={handleCancel} className="p-2">
           <ArrowLeftIcon className="h-6 w-6" />

--- a/server.log
+++ b/server.log
@@ -1,3 +1,9 @@
 
 > dev
 > react-router dev
+
+Port 5173 is in use, trying another one...
+Port 5174 is in use, trying another one...
+Port 5175 is in use, trying another one...
+  ➜  Local:   http://localhost:5176/
+  ➜  Network: use --host to expose


### PR DESCRIPTION
## Problem
Users reported that after saving a waypoint with an image from an iPhone, the image would fail to render both in the saved waypoints list view and in the edit view.

## Cause
The issue stems from how base64 image strings are transmitted during form submission. By default, forms use `application/x-www-form-urlencoded`. Under this encoding, the `+` character (which is a valid and common character in base64 strings) is translated into a space (` `). This substitution corrupts the base64 string, causing the browser to fail to decode and render the image.

## Solution
Changed the encoding type of the forms in `app/routes/add_waypoint.tsx` and `app/routes/edit_waypoint.tsx` to `multipart/form-data`. This encoding method safely transmits the raw string data without performing URL encoding character substitutions, preserving the `+` signs in the base64 data.

---
*PR created automatically by Jules for task [8272327393980150008](https://jules.google.com/task/8272327393980150008) started by @marcusholmgren*